### PR TITLE
Added 'textIndent' to the list of styles considered for size detection.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -14,7 +14,8 @@
 		'fontStyle',
 		'letterSpacing',
 		'textTransform',
-		'wordSpacing'
+		'wordSpacing',
+		'textIndent'
 	],
 	oninput = 'oninput',
 	onpropertychange = 'onpropertychange',

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@ Small jQuery plugin to allow dynamic resizing of textarea height, so that it gro
 
 ## Changelog
 
+### Master
+* Added 'textIndent' to the list of styles considered for size detection.
+
 ### Version 1.8 - June 7, 2012
 * Added conditional so that autosize cannot be applied twice to the same element
 * When autosize is applied to an element, it will have a data property that links it to the mirrored textarea element.  This will make it easier to keep track of and remove unneeded mirror elements.  Example:


### PR DESCRIPTION
`<textarea>` tags can have their first line indented with the CSS `text-indent` property. It's worth copying this style to the mirror so that it can factor into the computed height of the `<textarea>`.
