### PR TITLE
Removed the resize handle which is made obsolete by this plugin.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -60,13 +60,11 @@
 				} else {
 					mirror = $(copy).data('ismirror', true).addClass(className || 'autosizejs')[0];
 
-					resize = $ta.css('resize') === 'none' ? 'none' : 'horizontal';
-
 					$ta.data('mirror', $(mirror)).css({
 						overflow: hidden,
 						overflowY: hidden,
 						wordWrap: 'break-word',
-						resize: resize
+						resize: 'none'
 					});
 				}
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@ Small jQuery plugin to allow dynamic resizing of textarea height, so that it gro
 
 ## Changelog
 
+### Version 1.13 - September 4, 2012
+* Removed the resize handle which is made obsolete by this plugin.
+
 ### Version 1.12 - September 3, 2012
 * Fixed a bug I introduced in the last update.
 


### PR DESCRIPTION
When you have this plugin and it’s in a browser where it works, there’s no reason to have the resize handle still there. Using it would just result in people accidentally screwing up the layout.

I’m not sure if I did it right though, so please review. :)

(By the way, thank you for the magnificent plugin!)
