### PR TITLE
Extend autosize to allow a callback on resize

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -35,7 +35,10 @@
 			copyStyle.push(lineHeight);
 		}
 
-		$.fn.autosize = function (className) {
+		$.fn.autosize = function (options) {
+			if (typeof options == 'string') options = { className: options };
+			var className = options.className;
+
 			return this.each(function () {
 				var
 				ta = this,
@@ -111,6 +114,9 @@
 						setTimeout(function () {
 							active = false;
 						}, 1);
+
+						if (typeof options.callback == "function")
+							options.callback.call(this);
 					}
 				}
 
@@ -156,7 +162,7 @@
 		};
 	} else {
 		// Makes no changes for older browsers (FireFox3- and Safari4-)
-		$.fn.autosize = function () {
+		$.fn.autosize = function (callback) {
 			return this;
 		};
 	}


### PR DESCRIPTION
I've changed the plugin from taking a single 'className' argument (which I noticed wasn't referenced in the docs) to an 'options' object which takes properties 'className' and 'callback', while retaining backwards compatibility with existing $.autosize(className) code.
