### PR TITLE
Fixing Border-Box issue #28

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -95,7 +95,7 @@
 						original = parseInt(ta.style.height,10);
 
 						// Update the width in case the original textarea width has changed
-						mirror.style.width = $ta.css('width');
+						mirror.style.width = $ta.width() + 'px';
 
 						// Needed for IE to reliably return the correct scrollHeight
 						mirror.scrollTop = 0;


### PR DESCRIPTION
This fixes the wrong height issue for border-box textarea's. It adjusts the width of the mirrored textarea to be the width without padding and border of a border-box textarea.
