### PR TITLE
Exit for un-rendered element

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -57,6 +57,11 @@
 				value = ta.value,
 				callback = $.isFunction(options.callback);
 
+        // if minimum height is 0 or lower then the element hasn't been rendered yet so exit.
+        if (minHeight <= 0) {
+          return;
+        }
+
 				if ($ta.css('box-sizing') === borderBox || $ta.css('-moz-box-sizing') === borderBox || $ta.css('-webkit-box-sizing') === borderBox){
 					boxOffset = $ta.outerHeight() - $ta.height();
 				}


### PR DESCRIPTION
I didn't have much time so I implemented this quick fix for my project.

The textarea sizes where huge if I ran autosize on them before they where inserted into the DOM. My first instinct was to stop the plugin from doing anything if it seems that the element hasn't been rendered yet.

I guess it might be more specific (but slower) to check if the 'body' element is an ancestor of the element being autosized. What do you think?
