### PR TITLE
Add check so mirror is only appended to body once. 

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -14,7 +14,7 @@
 	lineHeight = 'lineHeight',
 
 	// border:0 is unnecessary, but avoids a bug in FireFox on OSX (http://www.jacklmoore.com/autosize#comment-851)
-	copy = '<textarea tabindex="-1" style="position:absolute; top:-9999px; left:-9999px; right:auto; bottom:auto; border:0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden;"/>',
+	copy = '<textarea id="jq-autosize-mirror" tabindex="-1" style="position:absolute; top:-9999px; left:-9999px; right:auto; bottom:auto; border:0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden;"/>',
 	
 	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
 	copyStyle = [
@@ -46,7 +46,12 @@
 	$.fn.autosize = function (options) {
 		options = $.extend({}, defaults, options || {});
 
-		$(mirror).appendTo('body');
+        if ($('#jq-autosize-mirror').length == 0) {
+    		$(mirror).appendTo('body');
+        }
+        else {
+            mirror = $('#jq-autosize-mirror')[0];
+        }
 
 		return this.each(function () {
 			var


### PR DESCRIPTION
Thanks for the plugin!  I'm using it on pages where textareas are created via ajax.  I saw that multiple mirror elements were appended to the body. So I modified the code to add an id for the mirror element, and check for that element before appending to body.
