### PR TITLE
Existing vertical resize css being replaced with horizontal

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -69,7 +69,7 @@
 				boxOffset = $ta.outerHeight() - $ta.height();
 			}
 
-			resize = $ta.css('resize') === 'none' ? 'none' : 'horizontal';
+			resize = ($ta.css('resize') === 'none' || $ta.css('resize') === 'vertical') ? 'none' : 'horizontal';
 
 			$ta.css({
 				overflow: hidden,


### PR DESCRIPTION
If a textarea has resize set to vertical, applying autosize will reset that to horizontal. This is probably not desired behaviour, so I've added a small patch to change it to none instead.

Regards,
Jamie
