### PR TITLE
IE8 error Invalid argument when textarea has display:none 

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -113,7 +113,7 @@
 					original = parseInt(ta.style.height,10);
 
 					// Update the width in case the original textarea width has changed
-					mirror.style.width = $ta.width() + 'px';
+					mirror.style.width = ($ta.width() < 0 ? 0 : $ta.width()) + 'px';
 
 					// The following three lines can be replaced with `height = mirror.scrollHeight` when dropping IE7 support.
 					mirror.scrollTop = 0;


### PR DESCRIPTION
on IE8 when textarea has display:none causes error:  Invalid argument. 
jquery.autosize.js, line 116 character 6

the width() returned by jQuery is a negative number, assigning it in IE8
causes the error.
