### PR TITLE
textarea passed in as parameter as well as 'this' element

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -147,7 +147,7 @@
 					if (original !== height) {
 						ta.style.height = height + 'px';
 						if (callback) {
-							options.callback.call(ta);
+							options.callback.call(ta,ta);
 						}
 					}
 


### PR DESCRIPTION
This makes it easier to work with TypeScript's 'this' in lambdas;

i.e. callback: ta => this.doSomething(ta) //'this' from callback is lost

This may also be an issue with ECMAScript 6 lambdas. This shouldn't be a breaking change, it's just adding a parameter where there wasn't one previously.
