### PR TITLE
Bind resize event only the window object

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -173,9 +173,11 @@
 				ta[oninput] = adjust;
 			}
 
-			$(window).on('resize', function(){
-				active = false;
-				adjust();
+			$(window).on('resize', function(e){
+				if(e.target === window){
+					active = false;
+					adjust();
+				}
 			});
 
 			// Allow for manual triggering if needed.


### PR DESCRIPTION
I was trying to use your great plugin together with some stuff I hacked with the jQuery UI Resizable plugin. After I activated your plugin, the resizable stuff didn't work anymore.

My solution is to bind the resize event handler only to the window object. Everything works as expected with this.

If it hasn't any side effects I didn't consider, maybe you want to merge my little patch.
