### PR TITLE
IE8: ensures that the initial height is used if min-height is not set

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -74,7 +74,7 @@
 				boxOffset = $ta.outerHeight() - $ta.height();
 			}
 
-			minHeight = Math.max(parseInt($ta.css('minHeight'), 10) - boxOffset, $ta.height());
+			minHeight = Math.max(parseInt($ta.css('minHeight'), 10) - boxOffset || 0, $ta.height());
 
 			resize = ($ta.css('resize') === 'none' || $ta.css('resize') === 'vertical') ? 'none' : 'horizontal';
 


### PR DESCRIPTION
Sorry to bother you again :)

But I found out that IE8 ignores the initial height if `min-height` is not set. That's because `parseInt($ta.css('minHeight'), 10)` returns `NaN` in that case.
