### PR TITLE
prevent change of cursor position at "workaround chrome"

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -105,7 +105,7 @@
 					var carretPos = $(ta).prop('selectionStart');
 					ta.value = '';
 					ta.value = value;
-					if (carretPos) $(ta).get(0).setSelectionRange(carretPos,carrentPos);
+					if (carretPos) $(ta).get(0).setSelectionRange(carretPos,carretPos);
 				}
 			}
 


### PR DESCRIPTION
prevent change of cursor position when alternate between textareas with different styles
