### PR TITLE
Explicitly set the padding of the textarea to 0

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -22,7 +22,7 @@
 	},
 
 	// border:0 is unnecessary, but avoids a bug in FireFox on OSX
-	copy = '<textarea tabindex="-1" style="position:absolute; top:-999px; left:0; right:auto; bottom:auto; border:0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden; transition:none; -webkit-transition:none; -moz-transition:none;"/>',
+	copy = '<textarea tabindex="-1" style="position:absolute; top:-999px; left:0; right:auto; bottom:auto; border:0; padding: 0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden; transition:none; -webkit-transition:none; -moz-transition:none;"/>',
 
 	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
 	typographyStyles = [


### PR DESCRIPTION
If textareas are styled to have a width of 100%, as well as a non-zero padding, the "invisible" textarea inserted by autosize.js will increase the width of the page by the amount of the padding, resulting in a horizontal scrollbar.

This may seem like an edge case, but the popular CSS framework Foundation sets those properties by default as part of their form styling.

The fix is to explicitly set the padding of the invisible textarea to 0. I have tested this on my site and it solves the issue without affecting autosize's functionality.
