### PR TITLE
Prevent autofocus of textarea in Chrome.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -137,10 +137,16 @@
 				// When the textarea y-overflow is hidden, Chrome doesn't reflow the text to account for the space
 				// made available by removing the scrollbar. This workaround triggers the reflow for Chrome.
 				if (window.chrome && 'setSelectionRange' in ta) {
+					var $activeElement = $(document.activeElement || 'body');
 					var cursorIndex = ta.selectionStart;
 					ta.value += ' ';
 					ta.value = ta.value.slice(0,-1);
 					ta.setSelectionRange(cursorIndex,cursorIndex);
+
+					if (!$activeElement.is($ta)) {
+						$ta.blur();
+						$activeElement.focus();
+					}
 				}
 			}
 


### PR DESCRIPTION
Chrome (tested in 31.0.1618.0 canary) automatically focuses a textarea once you retrieve it's cursor index. And as if that's not weird enough, in order to get Chrome to behave properly, I had to first `.blur()` the current textarea, and then `.focus()` the currently active element. Normally `.focus()` alone should suffice, but not here for some strange reason.

This is especially an issue when you have another input field on the page that makes use of the `autofocus` attribute, that field will receive focus initially, then immediately switch focus to the textarea that makes use of `autosize`.
