### PR TITLE
Adds support for additional space on the bottom of the textarea.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -10,7 +10,8 @@
 		className: 'autosizejs',
 		append: '',
 		callback: false,
-		resizeDelay: 10
+		resizeDelay: 10,
+		extraBottomSpace: 20
 	},
 
 	// border:0 is unnecessary, but avoids a bug in Firefox on OSX
@@ -173,7 +174,7 @@
 					}
 				}
 
-				height += boxOffset;
+				height += (boxOffset + options.extraBottomSpace);
 
 				if (original !== height) {
 					ta.style.height = height + 'px';


### PR DESCRIPTION
Example of use case scenario:
![textarea](https://f.cloud.github.com/assets/766837/1612271/2bb52040-55c0-11e3-86b2-c25481319d18.png)

I've built a custom placeholder kindalike for my textareas. The extra space allows me to do so without overlapping the text. Could be useful for other stuff as well.
