### PR TITLE
If textarea is empty, and placeholder text exists, use placeholder text for sizing.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -151,11 +151,15 @@
 					setWidth();
 				}
 
-			        if (!ta.value) {
-			          mirror.value = $(ta).attr("placeholder") + options.append;
-			        } else {
-			          mirror.value = ta.value + options.append;
-			        }
+				if (!ta.value) {
+					// If the textarea is empty, copy the placeholder text into 
+					// the mirror control and use that for sizing so that we 
+					// don't end up with placeholder getting trimmed.
+					mirror.value = ($(ta).attr("placeholder") || '') + options.append;
+				} else {
+					mirror.value = ta.value + options.append;
+				}
+
 				mirror.style.overflowY = ta.style.overflowY;
 				original = parseInt(ta.style.height,10);
 


### PR DESCRIPTION
Hopefully this makes sense to do.  We were having problems where a larger placeholder comment was being cut off on mobile devices where the textarea was forced to be narrow.  Adding this makes sure that the textarea is sized for the placeholder text if the textarea is empty.
