### PR TITLE
Fixes some situations where element is 'offscreen'

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -101,13 +101,14 @@
 					$.each(['paddingLeft', 'paddingRight', 'borderLeftWidth', 'borderRightWidth'], function(i,val){
 						width -= parseInt(style[val],10);
 					});
-
-					mirror.style.width = width + 'px';
 				}
-				else {
+				if (!style || width == 0) {
 					// window.getComputedStyle, getBoundingClientRect returning a width are unsupported and unneeded in IE8 and lower.
-					mirror.style.width = Math.max($ta.width(), 0) + 'px';
+                    // In some situations, if the element is offscreen, then the above approach will result in 0 width,
+                    // but the approach below works.
+					mirror.style.width = Math.max($ta.width(), 0);
 				}
+                mirror.style.width = width + 'px';
 			}
 
 			function initMirror() {


### PR DESCRIPTION
This is a change to setWidth that addresses at least some cases where the size calculation doesn't currently work, because the element is offscreen (in my case, contained in an element that has display: none). The textarea had an explicit pixel width set, but still no joy.

In this situation, getBoundingClientRect() results in a width calculated to be 0, but the fallback calculation (for IE8 and lower) gives the right result.

This fixed the one problem I had when using autosize, and doesn't break any existing work cases.

Cheers,
Neil
