### PR TITLE
Fix minimum size under Firefox/Bootstrap 3.1

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -82,7 +82,7 @@
 			}
 
 			// IE8 and lower return 'auto', which parses to NaN, if no min-height is set.
-			minHeight = Math.max(parseInt($ta.css('minHeight'), 10) - boxOffset || 0, $ta.height());
+			minHeight = Math.max(parseInt($ta.css('minHeight'), 10) - boxOffset || 0, $ta.height() - boxOffset);
 
 			$ta.css({
 				overflow: 'hidden',


### PR DESCRIPTION
In Firefox with Bootstrap 3.1, I was seeing that textarea with class form-control was too tall at it's minimum height.  This change solves that issue while not breaking other browsers.