### PR TITLE
update package.json to prevent warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"description": "Automatically adjust textarea height based on user input.",
 	"version": "1.18.9",
 	"dependencies": {},
+	"repository": {
+	    "type": "git",
+	    "url": "git://github.com/jackmoore/autosize.git"
+	},
 	"keywords": [
 		"form",
 		"textarea",


### PR DESCRIPTION
as of NPM v1.2.20, npm reports warning when repository is missing.
