### PR TITLE
IE11 - large, unbroken words do not wrap correctly

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -89,6 +89,7 @@
 			$ta.css({
 				overflow: 'hidden',
 				overflowY: 'hidden',
+				whiteSpace: 'pre-wrap', // fix IE11 text word-wrap issue
 				wordWrap: 'break-word' // horizontal overflow is hidden, so break-word is necessary for handling words longer than the textarea width
 			});
 


### PR DESCRIPTION
Hi @jackmoore,

There is an issue with IE11 for large, unbroken words... they do not wrap correctly. This doesn't affect IE10 or below.

http://stackoverflow.com/questions/20149715/internet-explorer-11-word-wrap-is-not-working

Cheers,
Nigel (@wtfiwtz)
