### PR TITLE
IE8: surrounding elements do not repaint to reflect new textarea height

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -200,6 +200,10 @@
 
 				if (original !== height) {
 					ta.style.height = height + 'px';
+
+					// Trigger a repaint for IE8 for when ta is nested 2 or more levels inside an inline-block
+					mirror.className = mirror.className;
+
 					if (callback) {
 						options.callback.call(ta,ta);
 					}


### PR DESCRIPTION
If the textarea is found nested 2 or more levels inside an inline-block element, then the surrounding elements do not get repainted.

http://jsfiddle.net/e2scs4y3/5/

As the textarea expands, it expands without pushing the neighboring element down.  Once the text is highlighted, then IE8 will trigger the repaint and render correctly.  I think this is the same issue as described in http://blog.caplin.com/2013/06/07/developing-for-ie8-inline-block-resize-bug/.

I was able to fix it by forcing a repaint on the mirror, only when the textarea's height has been updated.
