### PR TITLE
Fix jQuery undefined when using Zepto

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -270,4 +270,4 @@
 			adjust();
 		});
 	};
-}(jQuery || $)); // jQuery or jQuery-like library, such as Zepto
+}(window.jQuery || window.Zepto || window.$)); // jQuery or jQuery-like library, such as Zepto


### PR DESCRIPTION
When running the plugin under Zepto it was throwing an error, here is
the fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jackmoore/autosize/197)
<!-- Reviewable:end -->
