### PR TITLE
[CSP] Don't use inline styles.

### DIFF
--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -15,7 +15,23 @@
 	},
 
 	// border:0 is unnecessary, but avoids a bug in Firefox on OSX
-	copy = '<textarea tabindex="-1" style="position:absolute; top:-999px; left:0; right:auto; bottom:auto; border:0; padding: 0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden; transition:none; -webkit-transition:none; -moz-transition:none;"/>',
+	$copy = $('<textarea tabindex="-1"/>').css({
+    position: 'absolute',
+    top: '-999px',
+    left: 0,
+    right: 'auto',
+    bottom: 'auto',
+    border: 0,
+    padding: 0,
+    '-moz-box-sizing': 'content-box',
+    '-webkit-box-sizing': 'content-box',
+    boxSizing: 'content-box',
+    wordWrap: 'break-word',
+    overflow: 'hidden',
+    transition: 'none',
+    '-webkit-transition': 'none',
+    '-moz-transition': 'none'
+  }),
 
 	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
 	typographyStyles = [
@@ -34,7 +50,11 @@
 	mirrored,
 
 	// the mirror element, which is used to calculate what size the mirrored element should be.
-	mirror = $(copy).data('autosize', true)[0];
+	mirror = $copy.data('autosize', true)[0];
+
+  // apply !important styles.
+  mirror.style.setProperty('height', '0', 'important');
+  mirror.style.setProperty('minHeight', '0', 'important');
 
 	// test that line-height can be accurately copied.
 	mirror.style.lineHeight = '99px';

--- a/jquery.autosize.js
+++ b/jquery.autosize.js
@@ -16,22 +16,22 @@
 
 	// border:0 is unnecessary, but avoids a bug in Firefox on OSX
 	$copy = $('<textarea tabindex="-1"/>').css({
-    position: 'absolute',
-    top: '-999px',
-    left: 0,
-    right: 'auto',
-    bottom: 'auto',
-    border: 0,
-    padding: 0,
-    '-moz-box-sizing': 'content-box',
-    '-webkit-box-sizing': 'content-box',
-    boxSizing: 'content-box',
-    wordWrap: 'break-word',
-    overflow: 'hidden',
-    transition: 'none',
-    '-webkit-transition': 'none',
-    '-moz-transition': 'none'
-  }),
+		position: 'absolute',
+		top: '-999px',
+		left: 0,
+		right: 'auto',
+		bottom: 'auto',
+		border: 0,
+		padding: 0,
+		'-moz-box-sizing': 'content-box',
+		'-webkit-box-sizing': 'content-box',
+		boxSizing: 'content-box',
+		wordWrap: 'break-word',
+		overflow: 'hidden',
+		transition: 'none',
+		'-webkit-transition': 'none',
+		'-moz-transition': 'none'
+	}),
 
 	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
 	typographyStyles = [
@@ -52,9 +52,9 @@
 	// the mirror element, which is used to calculate what size the mirrored element should be.
 	mirror = $copy.data('autosize', true)[0];
 
-  // apply !important styles.
-  mirror.style.setProperty('height', '0', 'important');
-  mirror.style.setProperty('minHeight', '0', 'important');
+	// apply !important styles.
+	mirror.style.setProperty('height', '0', 'important');
+	mirror.style.setProperty('minHeight', '0', 'important');
 
 	// test that line-height can be accurately copied.
 	mirror.style.lineHeight = '99px';


### PR DESCRIPTION
Inline styles break CSP unless `unsafe-inline` is specified, which is a non-starter for some production sites.

I'm not 100% familiar with the requirements of the codebase/whether or not there are any tests, so happy to ACTION any feedback and squash before merging.

Also--what do you use to build the minified version?