### PR TITLE
Unbind destroy event from ta

### DIFF
--- a/dest/autosize.js
+++ b/dest/autosize.js
@@ -86,26 +86,22 @@
 			}
 		}
 
-		function destroy(){  
-			_destroy.call(ta, {
-				height: ta.style.height,
-				overflowY: ta.style.overflowY,
-				resize: ta.style.resize
-			});
-		}
-		 
-		function _destroy(style) {
+		var destroy = function(style){
 			window.removeEventListener('resize', update);
 			ta.removeEventListener('input', update);
 			ta.removeEventListener('keyup', update);
 			ta.removeAttribute('data-autosize-on');
 			ta.removeEventListener('autosize:destroy', destroy);
-		
+
 			Object.keys(style).forEach(function (key) {
-			ta.style[key] = style[key];
+				ta.style[key] = style[key];
 			});
-		}
-		
+		}.bind(ta, {
+			height: ta.style.height,
+			    overflowY: ta.style.overflowY,
+			    resize: ta.style.resize
+		});
+
 		ta.addEventListener('autosize:destroy', destroy);
 
 		// IE9 does not fire onpropertychange or oninput for deletions,

--- a/dest/autosize.js
+++ b/dest/autosize.js
@@ -86,21 +86,27 @@
 			}
 		}
 
-		ta.addEventListener('autosize:destroy', (function (style) {
+		function destroy(){  
+			_destroy.call(ta, {
+			height: ta.style.height,
+			overflowY: ta.style.overflowY,
+			resize: ta.style.resize
+			});
+		}
+		 
+		function _destroy(style) {
 			window.removeEventListener('resize', update);
 			ta.removeEventListener('input', update);
 			ta.removeEventListener('keyup', update);
 			ta.removeAttribute('data-autosize-on');
-			ta.removeEventListener('autosize:destroy');
-
+			ta.removeEventListener('autosize:destroy', destroy);
+		
 			Object.keys(style).forEach(function (key) {
-				ta.style[key] = style[key];
+			ta.style[key] = style[key];
 			});
-		}).bind(ta, {
-			height: ta.style.height,
-			overflowY: ta.style.overflowY,
-			resize: ta.style.resize
-		}));
+		}
+		
+		ta.addEventListener('autosize:destroy', destroy);
 
 		// IE9 does not fire onpropertychange or oninput for deletions,
 		// so binding to onkeyup to catch most of those events.

--- a/dest/autosize.js
+++ b/dest/autosize.js
@@ -88,9 +88,9 @@
 
 		function destroy(){  
 			_destroy.call(ta, {
-			height: ta.style.height,
-			overflowY: ta.style.overflowY,
-			resize: ta.style.resize
+				height: ta.style.height,
+				overflowY: ta.style.overflowY,
+				resize: ta.style.resize
 			});
 		}
 		 


### PR DESCRIPTION
The destroy event does not unbind as the bind() function returns a new function which is not used during unbind.

This fixes:
TypeError: Not enough arguments to EventTarget.removeEventListener.
ta.removeEventListener('autosize:destroy');
