### PR TITLE
Fix Windows Phone 8.1's Mobile IE (Nokia Lumia) jumpy behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,9 @@ bower install autosize
 
 #### Browser compatibility
 
-Chrome | Firefox | IE | Safari | iOS Safari | Android | Opera Mini
------- | --------|----|--------|------------|---------|------------
-yes    | yes     | 9  | yes    | yes        | 4       | ?
+Chrome | Firefox | IE | Safari | iOS Safari | Android | Opera Mini | Windows Phone IE
+------ | --------|----|--------|------------|---------|------------|------------------
+yes    | yes     | 9  | yes    | yes        | 4       | ?          | 8.1
 
 #### Usage
 

--- a/src/autosize.js
+++ b/src/autosize.js
@@ -47,7 +47,7 @@ function assign(ta, {setOverflowX = true, setOverflowY = true} = {}) {
 
 	function update() {
 		const startHeight = ta.style.height;
-		const htmlTop = document.documentElement.scrollTop;
+		const htmlTop = window.pageYOffset || document.documentElement.scrollTop;
 		const bodyTop = document.body.scrollTop;
 		const originalHeight = ta.style.height;
 
@@ -119,7 +119,7 @@ function assign(ta, {setOverflowX = true, setOverflowY = true} = {}) {
 	ta.addEventListener('input', update);
 	ta.addEventListener('autosize:update', update);
 	ta.setAttribute('data-autosize-on', true);
-	
+
 	if (setOverflowY) {
 		ta.style.overflowY = 'hidden';
 	}


### PR DESCRIPTION
Closes #239.

`document.documentElement.scrollTop` is inconsistent on Windows 8.1's Mobile IE (Nokia Lumia devices), so it now checks for the more reliable `window.pageYOffset` first.

I didn't build or pushed any tags, as I'm not sure how you'd like the contribution process to go.