### PR TITLE
Fix when a textarea is not on document body and heightOffset is Not a…

### DIFF
--- a/src/autosize.js
+++ b/src/autosize.js
@@ -18,7 +18,10 @@ function assign(ta, {setOverflowX = true, setOverflowY = true} = {}) {
 		} else {
 			heightOffset = parseFloat(style.borderTopWidth)+parseFloat(style.borderBottomWidth);
 		}
-
+		// Fix when a textarea is not on document body and heightOffset is Not a Number
+		if (isNaN(heightOffset))
+			heightOffset = 0;
+			
 		update();
 	}
 


### PR DESCRIPTION
When the textarea that is not on the body is intialized, the heightOffset is set as NaN then on update the value is not calculated and the height is not changed.