### PR TITLE
Fix fallback to ES5

### DIFF
--- a/dist/autosize.js
+++ b/dist/autosize.js
@@ -18,7 +18,7 @@
 })(this, function (exports, module) {
 	'use strict';
 
-	var set = Set ? new Set() : (function () {
+	var set = (typeof Set != "undefined") ? new Set() : (function () {
 		var list = [];
 
 		return {


### PR DESCRIPTION
With commit 08d62d08afde5c6cf54476fc2e184b6a3f97cd87 the `Set` object is used. This works fine with ES6, but not with ES5, because there is a bug in the fallback condition. You get a this error message:

````
ReferenceError: Can't find variable: Set
```

This PR fixes the fallback condition.