### PR TITLE
Fix IE10 issue referring to the present scrollbar until first resize when having min-height

### DIFF
--- a/src/autosize.js
+++ b/src/autosize.js
@@ -41,7 +41,7 @@ function assign(ta, {setOverflowX = true, setOverflowY = true} = {}) {
 		if (isNaN(heightOffset)) {
 			heightOffset = 0;
 		}
-	
+
 		update();
 	}
 
@@ -100,7 +100,7 @@ function assign(ta, {setOverflowX = true, setOverflowY = true} = {}) {
 
 		const style = window.getComputedStyle(ta, null);
 
-		if (style.height !== ta.style.height) {
+		if (parseInt(style.height) < parseInt(ta.style.height)) {
 			if (overflowY !== 'visible') {
 				changeOverflow('visible');
 			}


### PR DESCRIPTION
fix(IE10-scrollbar-issue): Fix IE10 issue referring to the present scrollbar in IE10 until first resize.

If a min-height is set on the textarea, the plugin displays a scrollbar even though it is not necessary. It is displayed at the beginning, until the first resize comes into place (https://jsfiddle.net/wg5yuu6e/1/).
It was fixed by changing the relation between the computed heights as IE10 offers a smaller value than the "real" one for height when computed  via the window object
