### PR TITLE
Added knockout binding handler

### DIFF
--- a/src/autosize-ko.js
+++ b/src/autosize-ko.js
@@ -1,0 +1,20 @@
+(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery', 'knockout'], factory);
+    } else {
+        factory(jQuery, ko);
+    }
+}(function($, ko) {
+    if (ko !== undefined && ko.bindingHandlers !== undefined) {
+        ko.bindingHandlers.autosize = {
+            init: function(element) {
+                element.addEventListener("focus", function() {
+                    autosize($(element));
+                });
+            },
+            update: function(element) {
+                autosize.update($(element));
+            }
+        };
+    }
+}));


### PR DESCRIPTION
Allows `<textarea data-bind="myText, autosize"></textarea>` with knockout.js.
