### PR TITLE
Remove border width from heightOffset

### DIFF
--- a/dist/autosize.js
+++ b/dist/autosize.js
@@ -78,7 +78,7 @@
 			if (style.boxSizing === 'content-box') {
 				heightOffset = -(parseFloat(style.paddingTop) + parseFloat(style.paddingBottom));
 			} else {
-				heightOffset = parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
+				heightOffset = -(parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth));
 			}
 			// Fix when a textarea is not on document body and heightOffset is Not a Number
 			if (isNaN(heightOffset)) {


### PR DESCRIPTION
Having set ‘content-type: border-box’ led to the textarea with a
border-top never returning to it’s original height after it gets
expanded and minimised. So we must minus the border width from the
heightOffset.

Example: http://recordit.co/ejQmt1CihN