### PR TITLE
Change overflow to scroll only if styleHeight is bigger then the actu…

### DIFF
--- a/src/autosize.js
+++ b/src/autosize.js
@@ -135,7 +135,7 @@ function assign(ta) {
 
 		// The actual height not matching the style height (set via the resize method) indicates that 
 		// the max-height has been exceeded, in which case the overflow should be allowed.
-		if (actualHeight !== styleHeight) {
+		if (actualHeight < styleHeight) {
 			if (computed.overflowY === 'hidden') {
 				changeOverflow('scroll');
 				resize();


### PR DESCRIPTION
Change overflow to scroll only if styleHeight is bigger then the actualHeight instead of not equal to. Fixes: show scroll bar when not needed.
use case: min-height set to value bigger then height.