### PR TITLE
Add module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "email": "hello@jacklmoore.com"
   },
   "main": "dist/autosize.js",
+  "module": "src/autosize.js",
   "license": "MIT",
   "homepage": "http://www.jacklmoore.com/autosize",
   "demo": "http://www.jacklmoore.com/autosize",


### PR DESCRIPTION
Webpack and Rollup use `module` field as default to import ES2015 modules.
https://webpack.js.org/configuration/resolve/#resolve-mainfields

It will give lesser app size by eliminating UMD wrapper.