### PR TITLE
add module field to package.json for ES Module imports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+##### v.4.0.3 - 2020-09-30
+* Add module field to package.json so autosize can be imported as an ES Module
+
 ##### v.4.0.2 - 2018-04-30
 * More specific detection of when to change overflow. Merges #361.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autosize",
   "description": "Autosize is a small, stand-alone script to automatically adjust textarea height to fit text.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "keywords": [
     "textarea",
     "form",
@@ -17,6 +17,7 @@
     "email": "hello@jacklmoore.com"
   },
   "main": "dist/autosize.js",
+  "module": "src/autosize.js",
   "license": "MIT",
   "homepage": "http://www.jacklmoore.com/autosize",
   "demo": "http://www.jacklmoore.com/autosize",


### PR DESCRIPTION
Hi! 

I used to import autosize in my project like:
```js
import autosize from 'autosize/src/autosize.js';
```
Which works fine. Then I switched to Typescript and installed @types/autosize, but this only works for me if I import like:
```js
import autosize from 'autosize';
```
But that only works if there is either:
- a default export in the module entrypoint (which does not yet exist)
- a default export in the main entrypoint, but that's IIFE format so there is no default export

Just adding the module field and pointing it to `src/autosize.js` would work great. 

I've taken the liberty to also bump and add a changelog entry since I couldn't find contribution guidelines or any signs of an automated publish step that does this. Hopefully that's okay 😅 . 

Kind regards,
Joren