### PR TITLE
Allow detached autosize DOM elements to be garbage collected

### DIFF
--- a/src/autosize.js
+++ b/src/autosize.js
@@ -9,8 +9,9 @@ function createResizeObserver() {
 		return new ResizeObserver((entries) => entries.forEach(e => onResize(e.target)));
 	}
 	// If not a modern environment, we use a Map instead of a WeakMap, which is iterable.
-	window.addEventListener('resize', () => assignedElements.forEach((_, el) => onResize(el)));
-	return { observe: () => {}, unobserve: () => {} };
+	const resizeCallback = () => assignedElements.forEach((_, el) => onResize(el));
+	window.addEventListener('resize', resizeCallback);
+	return { observe: () => {}, unobserve: () => {}, disconnect: () => window.removeEventListener('resize', resizeCallback)};
 }
 
 function onResize(el) {
@@ -147,7 +148,6 @@ function assign(ta) {
 		ta.removeEventListener('autosize:destroy', destroy);
 		ta.removeEventListener('autosize:update', fullSetHeight);
 		ta.removeEventListener('input', handleInput);
-		window.removeEventListener('resize', fullSetHeight); // future todo: consider replacing with ResizeObserver
 		Object.keys(style).forEach(key => ta.style[key] = style[key]);
 		assignedElements.delete(ta);
 		resizeObserver.unobserve(ta);

--- a/src/autosize.js
+++ b/src/autosize.js
@@ -14,10 +14,17 @@ function createResizeObserver() {
 	return { observe: () => {}, unobserve: () => {}, disconnect: () => window.removeEventListener('resize', resizeCallback)};
 }
 
+function getRelevantStyles(c) {
+	return `${c.width}-${c.height}-${c.padding}-${c.borderWidth}-${c.overflow}-${c.boxSizing}-${c.textAlign}`;
+}
+
 function onResize(el) {
 	const instance = assignedElements.get(el);
-	if (instance !== undefined) {
-		instance.update();
+	if (instance !== undefined && el.scrollHeight > 0) {
+		const styles = getRelevantStyles(instance.computed);
+		if (styles !== instance.previousStyles) {
+			instance.update();
+		}
 	}
 }
 
@@ -25,6 +32,7 @@ function assign(ta) {
 	if (!ta || !ta.nodeName || ta.nodeName !== 'TEXTAREA' || assignedElements.has(ta)) return;
 
 	let previousHeight = null;
+	let previousStyles = null;
 
 	function cacheScrollTops(el) {
 		const arr = [];
@@ -120,6 +128,8 @@ function assign(ta) {
 				testForHeightReduction: true,
 			});
 		}
+
+		previousStyles = getRelevantStyles(computed);
 	}
 
 	function fullSetHeight() {
@@ -170,6 +180,8 @@ function assign(ta) {
 	assignedElements.set(ta, {
 		destroy,
 		update: fullSetHeight,
+		get previousStyles() { return previousStyles; },
+		computed,
 	});
 
 	fullSetHeight();


### PR DESCRIPTION
The proper way is to use `autosize.destroy` when an autosize instance is no longer needed.

However, sometimes it may be hard to explicitly destroy existing widget instances. See for [this issue from another widget](https://github.com/autoNumeric/autoNumeric/issues/788) where the DOM element or DOM container element is simply removed. For example, try creating a simple demo page with a div container and some textareas with autosize, then remove the div container from the DOM. The `assignedElements` still contains all entries, and the memory tab of the dev tools shows many detached DOM elements that weren't garbage collected.

This happens because of 2 reasons: (a) The `assignedElements` map keeps  a hard reference to all DOM textareas and the autosize instances; (b) each instances adds a global `resize` event listener to the window, and the event listener captures the textarea DOM element with a closure.

There is a simple change that solves these issues:

* Use a weak map instead of a map. Supported in all modern browsers, for somewhat older browsers, we can still fall back to a map.
* Use a resize observer instead of a global event listener, as already mentioned in the code as a todo. Resize observer won't prevent the observed DOM elements from getting garbage collected. As a bonus, it will now also properly resize when the width is changed in any other. A global resize listener can still be used as a fallback when the environment does not support resize observers.
