### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "source": "src/autosize.js",
   "module": "dist/autosize.esm.js",
+  "sideEffects": false,
   "unpkg": "dist/autosize.min.js",
   "main": "dist/autosize.js",
   "license": "MIT",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good with esm, nodules, named imports;